### PR TITLE
remove signet test and add required argument in block header test

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -320,7 +320,6 @@ test_fuzz_fuzz_SOURCES = \
  test/fuzz/secp256k1_ec_seckey_import_export_der.cpp \
  test/fuzz/secp256k1_ecdsa_signature_parse_der_lax.cpp \
  test/fuzz/signature_checker.cpp \
- test/fuzz/signet.cpp \
  test/fuzz/socks5.cpp \
  test/fuzz/span.cpp \
  test/fuzz/spanparsing.cpp \

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -6,6 +6,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <chainparams.h>
 
 #include <cstdint>
 #include <optional>
@@ -33,7 +34,7 @@ FUZZ_TARGET(chain)
         (void)disk_block_index->IsValid();
     }
 
-    const CBlockHeader block_header = disk_block_index->GetBlockHeader();
+    const CBlockHeader block_header = disk_block_index->GetBlockHeader(Params().GetConsensus());
     (void)CDiskBlockIndex{*disk_block_index};
     (void)disk_block_index->BuildSkip();
 


### PR DESCRIPTION
This fixes the build process when not disabling tests. 2 tests fail but I assume you're probably waiting until mainnet to fix those so I left them alone.

