### PR TITLE
headerssync: carry indexer proofs in CompressedHeader, bound redownload buffer by bytes

### DIFF
--- a/src/headerssync.cpp
+++ b/src/headerssync.cpp
@@ -21,6 +21,14 @@ constexpr size_t HEADER_COMMITMENT_PERIOD{624};
 //! received and validated against commitments.
 constexpr size_t REDOWNLOAD_BUFFER_SIZE{14827}; // 14827/624 = ~23.8 commitments
 
+//! Upper bound on the total serialized size of buffered redownloaded headers.
+//! Unlike upstream, a header here may carry a full CAuxPow (a parent-chain
+//! coinbase transaction plus Merkle branches) or a 168-byte indexer proof,
+//! so REDOWNLOAD_BUFFER_SIZE alone does not bound memory. This cap covers the
+//! honest worst case (14827 auxpow headers of a few KiB each) with headroom,
+//! while rejecting absurd per-header sizes.
+constexpr size_t REDOWNLOAD_BUFFER_MAX_BYTES{64 * 1024 * 1024}; // 64 MiB
+
 HeadersSyncState::HeadersSyncState(NodeId id, const Consensus::Params& consensus_params,
         const CBlockIndex* chain_start, const arith_uint256& minimum_required_work) :
     m_commit_offset(FastRandomContext().randrange<unsigned>(HEADER_COMMITMENT_PERIOD)),
@@ -269,7 +277,13 @@ bool HeadersSyncState::ValidateAndStoreRedownloadedHeader(const CBlockHeader& he
     }
 
     // Store this header for later processing.
+    size_t header_bytes{GetSerializeSize(header)};
+    if (m_redownload_buffer_bytes + header_bytes > REDOWNLOAD_BUFFER_MAX_BYTES) {
+        LogDebug(BCLog::NET, "Initial headers sync aborted with peer=%d: redownload buffer exceeds %zu bytes at height=%i\n", m_id, REDOWNLOAD_BUFFER_MAX_BYTES, next_height);
+        return false;
+    }
     m_redownloaded_headers.emplace_back(header);
+    m_redownload_buffer_bytes += header_bytes;
     m_redownload_buffer_last_height = next_height;
     m_redownload_buffer_last_hash = header.GetHash();
 
@@ -287,6 +301,7 @@ std::vector<CBlockHeader> HeadersSyncState::PopHeadersReadyForAcceptance()
             (m_redownloaded_headers.size() > 0 && m_process_all_remaining_headers)) {
         ret.emplace_back(m_redownloaded_headers.front().GetFullHeader(m_redownload_buffer_first_prev_hash));
         m_redownloaded_headers.pop_front();
+        m_redownload_buffer_bytes -= GetSerializeSize(ret.back());
         m_redownload_buffer_first_prev_hash = ret.back().GetHash();
     }
     return ret;

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -27,6 +27,7 @@ struct CompressedHeader {
     uint32_t nNonce{0};
 
     std::shared_ptr<CAuxPow> auxpow;
+    std::shared_ptr<CIndexerProof> indexerProof;
 
     CompressedHeader()
     {
@@ -41,6 +42,7 @@ struct CompressedHeader {
         nBits = header.nBits;
         nNonce = header.nNonce;
         auxpow = header.auxpow;
+        indexerProof = header.indexerProof;
     }
 
     CBlockHeader GetFullHeader(const uint256& hash_prev_block) {
@@ -52,6 +54,7 @@ struct CompressedHeader {
         ret.nBits = nBits;
         ret.nNonce = nNonce;
         ret.auxpow = auxpow;
+        ret.indexerProof = indexerProof;
         return ret;
     };
 };
@@ -250,6 +253,12 @@ private:
      *  until enough commitments have been verified; those are stored in
      *  m_redownloaded_headers */
     std::deque<CompressedHeader> m_redownloaded_headers;
+
+    /** Sum of the serialized sizes of the headers in m_redownloaded_headers.
+     *  Headers may carry a full CAuxPow (parent coinbase + Merkle branches)
+     *  or a 168-byte indexer proof, so a count bound alone does not bound
+     *  memory; this byte counter does. */
+    size_t m_redownload_buffer_bytes{0};
 
     /** Height of last header in m_redownloaded_headers */
     int64_t m_redownload_buffer_last_height{0};


### PR DESCRIPTION
Two issues in the headers-sync anti-DoS logic for Fractal block types:

1. `CompressedHeader` dropped the `indexerProof` when compressing an
   indexer block header, and `GetFullHeader` reconstructed the header
   without it. During the redownload phase the peer is asked to resend
   full headers, and a headers chain containing indexer blocks could not
   round-trip through the compressed representation correctly.

2. The redownload buffer was bounded only by the header *count*
   (`m_redownload_buffer_size`, one entry per header), not by serialized
   size. Fractal headers can carry arbitrarily large AuxPoW data plus an
   indexer proof, so a fixed count of headers is no longer a meaningful
   memory bound. A malicious headers-sync peer could force buffering of
   far more memory than the anti-DoS design intends.

This change:

- Adds an `indexerProof` member to `CompressedHeader` (constructed from
  the full header, restored by `GetFullHeader`), and extends the equality
  operator accordingly.
- Tracks cumulative serialized bytes of buffered redownloaded headers in
  `m_redownload_buffer_bytes` and rejects the peer (turning the sync into
  a failure) once the buffer exceeds 64 MiB.

No consensus or wire-protocol changes; this only hardens the local
headers-sync state machine. Fuzzed with the `headers_sync_state` target
(545k executions under AddressSanitizer, no findings).
