### PR TITLE
pow: indexer blocks use powLimit even on regtest

### DIFF
--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -163,13 +163,16 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 {
     assert(pindexLast != nullptr);
 
+    // Indexer blocks always use powLimit, including on regtest. This check
+    // must precede the no-retargeting shortcut below, otherwise regtest
+    // indexer blocks would be required to carry the previous block's nBits.
+    if (pblock->IsIndexer()) {
+        return UintToArith256(params.powLimit).GetCompact();
+    }
+
     // Special rule for regtest: we never retarget.
     if (params.fPowNoRetargeting) {
         return pindexLast->nBits;
-    }
-
-    if (pblock->IsIndexer()) {
-        return UintToArith256(params.powLimit).GetCompact();
     }
 
     assert(params.asertAnchorParams.nHeight > 0);


### PR DESCRIPTION
In `GetNextWorkRequired`, the regtest no-retargeting shortcut
(`fPowNoRetargeting` → return previous `nBits`) was evaluated before the
indexer-block rule (return `powLimit`). On regtest, an indexer block
following a mined block would therefore be required to carry the previous
block's `nBits` instead of `powLimit`, contradicting the FIP-101 rule
that indexer blocks always use `powLimit` and breaking regtest setups
that mine indexer blocks after non-trivial-PoW blocks.

Reorder the checks so the indexer rule wins. Mainnet/testnet behavior is
unchanged (both checks only matter on regtest).

Test plan: `pow_tests` run (pre-existing Fractal DAA expectation
failures unchanged; no new failures).
